### PR TITLE
add SCOPE parameter in config, and add kts.init function

### DIFF
--- a/kts/__init__.py
+++ b/kts/__init__.py
@@ -6,6 +6,7 @@ sys.path.insert(0, '.')
 # from .environment import get_mode
 # get_mode()
 from . import config
+from . import init
 from .feature.decorators import preview, register, deregister, dropper, selector, helper
 from .feature import stl
 from .feature.storage import feature_list as features

--- a/kts/config.py
+++ b/kts/config.py
@@ -17,6 +17,8 @@ mode = 'local'
 GOAL = 'MAXIMIZE'
 MAX_LEN_SOURCE = 100
 
+SCOPE = globals()
+
 # cache_mode = 'disk_and_ram'  # "disk", "disk_and_ram", "ram"
 # cache_policy = 'everything'  # "everything", "service"
 

--- a/kts/feature/storage.py
+++ b/kts/feature/storage.py
@@ -336,7 +336,7 @@ class FeatureList(MutableSequence):
             self.name_to_idx[functor.__name__] = idx
 
     def __repr__(self):
-        self.recalc()
+        self.define_in_scope(config.SCOPE)
         string = f"[{', '.join([f.__str__() for f in self.functors])}]"
         return string
 

--- a/kts/init.py
+++ b/kts/init.py
@@ -2,3 +2,4 @@ from .config import SCOPE
 
 def init(scope):
 	SCOPE = scope
+

--- a/kts/init.py
+++ b/kts/init.py
@@ -1,0 +1,4 @@
+from .config import SCOPE
+
+def init(scope):
+	SCOPE = scope


### PR DESCRIPTION
Добавлен SCOPE параметр конфиг. Теперь метод __repr__ у features сам делает define_in_scope(SCOPE), где SCOPE параметр он берет из config.py. Чтобы задать этот параметр нужно импортировать kts -- "import kts", и вызвать kts.init -- "kts.init(MY_PERFECT_SCOPE)"