### PR TITLE
add calling define_in_scope of features every 1 sec after kts.init(scope)

### DIFF
--- a/kts/__init__.py
+++ b/kts/__init__.py
@@ -6,6 +6,7 @@ sys.path.insert(0, '.')
 # from .environment import get_mode
 # get_mode()
 from . import config
+from . import init
 from .feature.decorators import preview, register, deregister, dropper, selector, helper
 from .feature import stl
 from .feature.storage import feature_list as features

--- a/kts/config.py
+++ b/kts/config.py
@@ -17,6 +17,8 @@ mode = 'local'
 GOAL = 'MAXIMIZE'
 MAX_LEN_SOURCE = 100
 
+SCOPE = globals()
+
 # cache_mode = 'disk_and_ram'  # "disk", "disk_and_ram", "ram"
 # cache_policy = 'everything'  # "everything", "service"
 

--- a/kts/init.py
+++ b/kts/init.py
@@ -1,0 +1,17 @@
+import threading
+import time
+
+from .config import SCOPE
+from .feature.storage import feature_list as features
+
+def _define_in_scope():
+	while True:
+		features._define_in_scope(SCOPE)
+		time.sleep(1)
+
+
+def init(scope):
+	SCOPE = scope
+
+	scoping_thread = threading.Thread(target=_define_in_scope)
+	scoping_thread.start()


### PR DESCRIPTION
define_in_scope у features теперь вызывается каждую секунду, после объявления kts.init(MY_PERFECT_SCOPE). Значение MY_PERFECT_SCOPE записывается в kts.config как параметр SCOPE. В течении работы программы этот параметр можно менять, и define_in_scope метод будут работать с другим SCOPE.